### PR TITLE
Fix: Decode None Crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixes
+
+- Fixing the `decode_none` Rust function which would previously crash if it was decoding from a buffer of size 0.
+
 ## [v1.1.0] - 2023-06-07
 
 ### Changes

--- a/decoder.rs
+++ b/decoder.rs
@@ -75,12 +75,15 @@ pub trait Decoder {
 
 impl Decoder for Cursor<&mut Vec<u8>> {
     fn decode_none(&mut self) -> bool {
-        if let Ok(kind) = self.read_u8() {
-            if kind == Kind::None as u8 {
-                return true;
+        match self.read_u8() {
+            Ok(kind) => {
+                if kind == Kind::None as u8 {
+                    return true;
+                }
+                self.set_position(self.position() - 1);
             }
+            Err(_) => {},
         }
-        self.set_position(self.position() - 1);
         false
     }
 

--- a/decoder.rs
+++ b/decoder.rs
@@ -82,7 +82,7 @@ impl Decoder for Cursor<&mut Vec<u8>> {
                 }
                 self.set_position(self.position() - 1);
             }
-            Err(_) => {},
+            Err(_) => {}
         }
         false
     }


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue has been fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes an issue where calling `decode_none` on an empty buffer would crash the program. 

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] Bug fix (non-breaking change which fixes an issue) [title: 'fix:']
- [ ] New feature (non-breaking change which adds functionality) [title: 'feat:']
- [ ] Refactor (non-breaking change which does not add functionality) [title: 'refactor:']
- [ ] Breaking change (fix, feature, or refactor that would change existing functionality or interfaces) [title: 'BREAKING CHANGE:']
- [ ] This change requires a documentation update

## Testing

N/A

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have signed-off my commits with `git commit -s` (see [the developer's certificate of origin](https://github.com/apps/dco))