### PR TITLE
go: preserve nil structs on decode

### DIFF
--- a/v2/generator/golang/templates/decode.templ
+++ b/v2/generator/golang/templates/decode.templ
@@ -79,12 +79,12 @@ var err error
         }
         }
     {{ else -}}
-        if x.{{ CamelCaseName $field.Name }} == nil {
+        if !d.Nil() {
         x.{{ CamelCaseName $field.Name }} = New{{ CamelCase $field.Message.FullName }}()
-        }
         err = x.{{ CamelCaseName $field.Name }}.decode(d)
         if err != nil {
         return err
+        }
         }
     {{end -}}
 {{end -}}

--- a/v2/generator/golang/templates/structs.templ
+++ b/v2/generator/golang/templates/structs.templ
@@ -38,14 +38,7 @@
 
 {{define "getFunc"}}
 func New{{ CamelCase .FullName }}() *{{ CamelCase .FullName }} {
-    return &{{ CamelCase .FullName }}{
-        {{ range $i, $v := (MakeIterable .Fields.Len) -}}
-            {{ $field := $.Fields.Get $i -}}
-            {{ if and (eq $field.Kind 11) (ne $field.Cardinality 3) -}} {{/* protoreflect.MessageKind protoreflect.Repeated */ -}}
-                {{ CamelCaseName $field.Name }}: New{{ CamelCase $field.Message.FullName }}(),
-            {{end -}}
-        {{end -}}
-    }
+    return &{{ CamelCase .FullName }}{}
 }
 {{end}}
 


### PR DESCRIPTION
When decoding a struct with struct fields, the generated `decode()` method would replace the `nil` fields with an empty new struct. Since `nil` fields are stored in the original message with zero bytes (`0x00`), we can check for it before attempting to decode the field into an intialized zero value.