### PR TITLE
ci: fix `rustup` WASI target

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,12 +28,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+
       - name: Set up Rust
         run: |
           rustup toolchain install stable --profile minimal --no-self-update
           rustup default stable
-          rustup target add wasm32-wasi
+          rustup target add wasm32-wasip1
         shell: bash
 
       - name: Cargo fmt
@@ -42,8 +42,8 @@ jobs:
       - name: Cargo check
         run: cargo check
 
-      - name: Cargo check wasm32-wasi
-        run: cargo check --target wasm32-wasi
+      - name: Cargo check wasm32-wasip1
+        run: cargo check --target wasm32-wasip1
 
       - name: Run Tests (Rust)
         run: cargo test
@@ -81,6 +81,6 @@ jobs:
 
       - name: Install Valgrind
         run: sudo apt-get install valgrind -y
-        
+
       - name: Run Tests
         run: make clib_test


### PR DESCRIPTION
The `wasm32-wasi` target was renamed to `wasm32-wasip1` and removed in Rust v1.84.

https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html